### PR TITLE
Fix: refund related adjustment

### DIFF
--- a/.maintain/deploy.sh
+++ b/.maintain/deploy.sh
@@ -8,11 +8,6 @@ export MINTER_ACCOUNT_ID=$(dfx ledger account-id)
 dfx identity use default
 export DEFAULT_ACCOUNT_ID=$(dfx ledger account-id)
 
-dfx identity new custodian
-dfx identity use custodian
-export CUSTODIAN_PRINCIPAL=$(dfx identity get-principal)
-echo $CUSTODIAN_PRINCIPAL
-
 dfx deploy --specified-id ryjl3-tyaaa-aaaaa-aaaba-cai icp_ledger_canister --argument "
   (variant {
     Init = record {
@@ -38,6 +33,12 @@ dfx deploy --specified-id ryjl3-tyaaa-aaaaa-aaaba-cai icp_ledger_canister --argu
 # deploy index canister
 dfx deploy icp_index_canister --specified-id qhbym-qaaaa-aaaaa-aaafq-cai --argument '(record {ledger_id = principal "ryjl3-tyaaa-aaaaa-aaaba-cai"})'
 
+dfx identity new custodian
+dfx identity use custodian
+export CUSTODIAN_PRINCIPAL=$(dfx identity get-principal)
+echo $CUSTODIAN_PRINCIPAL
+
+# deploy backend canister
 dfx deploy icp_prototype_backend --argument "(15 : nat64, 10 : nat32  , \"ryjl3-tyaaa-aaaaa-aaaba-cai\", \"$CUSTODIAN_PRINCIPAL\")"
 
 # show current identity - default
@@ -52,33 +53,27 @@ dfx canister --network local call be2us-64aaa-aaaaa-qaabq-cai add_subaccount '()
 
 # create a new subaccount-id alternatively via ledger canister
 dfx canister --network local call ryjl3-tyaaa-aaaaa-aaaba-cai account_identifier \
-'(record {owner = principal "xyxs7-kj3vb-expvh-s4xcy-4lztk-beh3x-hszie-gzacr-zwq7n-x5nvp-cqe";subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01"})' --query \
+'(record {owner = principal "bd3sg-teaaa-aaaaa-qaaba-cai";subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01"})' --query \
 | tr -d '[\\,"\(\)]' | grep -o '[0-9a-f]\{2\}' | tr -d '\n'
-# d4ca21b8146775096697d95483697f0510efa958d177189ddb3cb1dd530d4670
-
-dfx canister --network local call ryjl3-tyaaa-aaaaa-aaaba-cai account_identifier \
-'(record {owner = principal "xyxs7-kj3vb-expvh-s4xcy-4lztk-beh3x-hszie-gzacr-zwq7n-x5nvp-cqe";subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\02"})' --query \
-| tr -d '[\\,"\(\)]' | grep -o '[0-9a-f]\{2\}' | tr -d '\n'
-# c5429aef37e6545324fb3425e770c7007aa2953287249a5a7311abd3f36799df
-
-dfx canister --network local call ryjl3-tyaaa-aaaaa-aaaba-cai account_identifier \
-'(record {owner = principal "xyxs7-kj3vb-expvh-s4xcy-4lztk-beh3x-hszie-gzacr-zwq7n-x5nvp-cqe";subaccount = blob "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\03"})' --query \
-| tr -d '[\\,"\(\)]' | grep -o '[0-9a-f]\{2\}' | tr -d '\n'
-# b84c1d3331a948677d40ab367e337246b506e91db01881eb7e05004175d7404e
+# a8c85a1ebb81da856134eb6da837d4ee62d1189ef201c25db50f04673126ba3e
 
 
 # transfer to custodian subaccount-id 001
-dfx ledger transfer --network local --amount 1.25 --memo 001 d4ca21b8146775096697d95483697f0510efa958d177189ddb3cb1dd530d4670
+dfx ledger transfer --network local --amount 1.25 --memo 001 a8c85a1ebb81da856134eb6da837d4ee62d1189ef201c25db50f04673126ba3e
 
 # transfer to custodian subaccount-id 002
-dfx ledger transfer --network local --amount 2.75 --memo 002 c5429aef37e6545324fb3425e770c7007aa2953287249a5a7311abd3f36799df
+dfx ledger transfer --network local --amount 2.75 --memo 002 b79ddc484d7c8801e5e3ae4d0480f65258ad89e7f31d3a973e278e0823553230
 
 # transfer to custodian subaccount-id 003
-dfx ledger transfer --network local --amount 1.35 --memo 003 b84c1d3331a948677d40ab367e337246b506e91db01881eb7e05004175d7404e
+dfx ledger transfer --network local --amount 1.35 --memo 003 5d0df26150362dadf5a09d8ae91d1f16824b27f75de42b8a6c378e650492f014
+
+# check balance subaccount-id 001 via dfx - no longer viable
+# dfx identity use custodian
+# dfx ledger balance --subaccount 0000000000000000000000000000000000000000000000000000000000000001
 
 # set interval to 5 sec
 
 # call list_transactions
 
-# refund tx
-dfx canister --network local call be2us-64aaa-aaaaa-qaabq-cai refund '(1: nat64)' 
+# refund tx - no longer viable
+# dfx canister --network local call be2us-64aaa-aaaaa-qaabq-cai refund '(1: nat64)' 

--- a/.maintain/deploy.sh
+++ b/.maintain/deploy.sh
@@ -1,3 +1,4 @@
+#------------------------------ PART #1 DEPLOYMENT ------------------------------
 # start local ICP network
 dfx start --clean --background
 
@@ -30,9 +31,6 @@ dfx deploy --specified-id ryjl3-tyaaa-aaaaa-aaaba-cai icp_ledger_canister --argu
   })
 "
 
-# deploy index canister
-dfx deploy icp_index_canister --specified-id qhbym-qaaaa-aaaaa-aaafq-cai --argument '(record {ledger_id = principal "ryjl3-tyaaa-aaaaa-aaaba-cai"})'
-
 dfx identity new custodian
 dfx identity use custodian
 export CUSTODIAN_PRINCIPAL=$(dfx identity get-principal)
@@ -40,6 +38,8 @@ echo $CUSTODIAN_PRINCIPAL
 
 # deploy backend canister
 dfx deploy icp_prototype_backend --argument "(15 : nat64, 10 : nat32  , \"ryjl3-tyaaa-aaaaa-aaaba-cai\", \"$CUSTODIAN_PRINCIPAL\")"
+
+#------------------------------ PART #2 TESTING ------------------------------
 
 # show current identity - default
 dfx identity use default
@@ -58,22 +58,21 @@ dfx canister --network local call ryjl3-tyaaa-aaaaa-aaaba-cai account_identifier
 # a8c85a1ebb81da856134eb6da837d4ee62d1189ef201c25db50f04673126ba3e
 
 
-# transfer to custodian subaccount-id 001
+# transfer to canister subaccount-id 001
 dfx ledger transfer --network local --amount 1.25 --memo 001 a8c85a1ebb81da856134eb6da837d4ee62d1189ef201c25db50f04673126ba3e
 
-# transfer to custodian subaccount-id 002
+# transfer to canister subaccount-id 002
 dfx ledger transfer --network local --amount 2.75 --memo 002 b79ddc484d7c8801e5e3ae4d0480f65258ad89e7f31d3a973e278e0823553230
 
-# transfer to custodian subaccount-id 003
+# transfer to custcanisterodian subaccount-id 003
 dfx ledger transfer --network local --amount 1.35 --memo 003 5d0df26150362dadf5a09d8ae91d1f16824b27f75de42b8a6c378e650492f014
 
-# check balance subaccount-id 001 via dfx - no longer viable
-# dfx identity use custodian
-# dfx ledger balance --subaccount 0000000000000000000000000000000000000000000000000000000000000001
+# test list_transactions via CandidUI
 
-# set interval to 5 sec
+# test refund via CandidUI
 
-# call list_transactions
+# test swap via CandidUI
 
-# refund tx - no longer viable
-# dfx canister --network local call be2us-64aaa-aaaaa-qaabq-cai refund '(1: nat64)' 
+# check custodian balance to confirm sweep
+dfx identity use custodian
+dfx ledger balance 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +273,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3d204af0b11c45715169c997858edb58fa8407d08f4fae78a6b415dd39a362"
 dependencies = [
  "candid",
- "ic-cdk-macros",
+ "ic-cdk-macros 0.8.4",
+ "ic0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8859bc2b863a77750acf199e1fb7e3fc403e1b475855ba13f59cb4e4036d238"
+dependencies = [
+ "candid",
+ "ic-cdk-macros 0.13.2",
  "ic0",
  "serde",
  "serde_bytes",
@@ -288,17 +307,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-macros"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ic-cdk-timers"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c43b9706fef3ad10c4192a14801d16bd9539068239f0f06f257857441364329"
 dependencies = [
  "futures",
- "ic-cdk",
+ "ic-cdk 0.12.1",
  "ic0",
  "serde",
  "serde_bytes",
  "slotmap",
+]
+
+[[package]]
+name = "ic-ledger-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d162fc508161221cc57bec8c0c4e029ae7c9eb92db461237499bb38c811ed4e"
+dependencies = [
+ "candid",
+ "crc32fast",
+ "hex",
+ "ic-cdk 0.13.2",
+ "serde",
+ "serde_bytes",
+ "sha2",
 ]
 
 [[package]]
@@ -336,13 +384,32 @@ dependencies = [
  "candid",
  "crc32fast",
  "hex",
- "ic-cdk",
- "ic-cdk-macros",
+ "ic-cdk 0.12.1",
+ "ic-cdk-macros 0.8.4",
  "ic-cdk-timers",
+ "ic-ledger-types",
  "ic-stable-structures",
+ "icrc-ledger-types",
  "once_cell",
  "serde",
  "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "icrc-ledger-types"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c892bf95652101660a25cea10f059f73eb8973f6b04e0349758fda1190447"
+dependencies = [
+ "base32",
+ "candid",
+ "crc32fast",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "serde_bytes",
  "sha2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +34,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base32"
@@ -50,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +99,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "candid"
@@ -261,6 +303,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +449,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -439,10 +494,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -475,10 +560,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "paste"
@@ -537,6 +664,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +689,12 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -611,6 +759,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +783,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -684,6 +857,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,3 +943,142 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "crc32fast",
+ "futures",
  "hex",
  "ic-cdk 0.12.1",
  "ic-cdk-macros 0.8.4",

--- a/src/icp_prototype_backend/Cargo.toml
+++ b/src/icp_prototype_backend/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 once_cell = "1.15"
 
 [dependencies]
+futures = "0.3"
 serde = "1.0.197"
 serde_json = "1.0"
 sha2 = "0.10.8"

--- a/src/icp_prototype_backend/Cargo.toml
+++ b/src/icp_prototype_backend/Cargo.toml
@@ -20,6 +20,8 @@ hex = "0.4.3"
 
 candid = "0.10"
 ic-cdk = "0.12"
-ic-cdk-timers = "0.6" # Feel free to remove this dependency if you don't need timers
+ic-cdk-timers = "0.6"
+icrc-ledger-types = "0.1.5"
+ic-ledger-types = "0.10.0"
 ic-cdk-macros = "0.8.4"
 ic-stable-structures = "0.6.3"

--- a/src/icp_prototype_backend/Cargo.toml
+++ b/src/icp_prototype_backend/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dev-dependencies]
 once_cell = "1.15"
+tokio = { version = "1.0", features = ["full", "macros"] }
 
 [dependencies]
 futures = "0.3"

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -21,12 +21,14 @@ type Result = variant { Ok : text; Err : Error };
 type Result_1 = variant { Ok : vec StoredTransactions; Err : Error };
 type Result_2 = variant { Ok : nat64; Err : Error };
 type StoredTransactions = record {
+  sweep_status : SweepStatus;
   memo : nat64;
   icrc1_memo : opt vec nat8;
   operation : opt Operation;
   index : nat64;
   created_at_time : Timestamp;
 };
+type SweepStatus = variant { Swept; FailedToSweep; NotSwept };
 type Timestamp = record { timestamp_nanos : nat64 };
 type Transfer = record {
   to : vec nat8;
@@ -50,5 +52,5 @@ service : (nat64, nat32, text, text) -> {
   refund : (nat64) -> (Result);
   set_interval : (nat64) -> (Result_2);
   set_next_block : (nat64) -> ();
-  sweep_user_vault : (text) -> (Result);
+  sweep_user_vault : () -> (Result);
 }

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -20,6 +20,7 @@ type Operation = variant {
 type Result = variant { Ok : text; Err : Error };
 type Result_1 = variant { Ok : vec StoredTransactions; Err : Error };
 type Result_2 = variant { Ok : nat64; Err : Error };
+type Result_3 = variant { Ok : vec text; Err : Error };
 type StoredTransactions = record {
   sweep_status : SweepStatus;
   memo : nat64;
@@ -53,4 +54,5 @@ service : (nat64, nat32, text, text) -> {
   refund : (nat64) -> (Result);
   set_interval : (nat64) -> (Result_2);
   set_next_block : (nat64) -> ();
+  sweep : () -> (Result_3);
 }

--- a/src/icp_prototype_backend/icp_prototype_backend.did
+++ b/src/icp_prototype_backend/icp_prototype_backend.did
@@ -41,6 +41,7 @@ service : (nat64, nat32, text, text) -> {
   add_subaccount : () -> (text);
   canister_status : () -> (Result) query;
   clear_transactions : (opt nat64, opt Timestamp) -> (Result_1);
+  get_canister_principal : () -> (text) query;
   get_interval : () -> (Result_2) query;
   get_next_block : () -> (nat64) query;
   get_nonce : () -> (nat32) query;
@@ -52,5 +53,4 @@ service : (nat64, nat32, text, text) -> {
   refund : (nat64) -> (Result);
   set_interval : (nat64) -> (Result_2);
   set_next_block : (nat64) -> ();
-  sweep_user_vault : () -> (Result);
 }

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -120,8 +120,13 @@ impl InterCanisterCallManagerTrait for InterCanisterCallManager {
     async fn icrc1_transfer(
         ledger_principal: Principal,
         req: Icrc1TransferRequest,
-    ) -> CallResult<(Icrc1TransferResponse,)> {
-        ic_cdk::call(ledger_principal, "icrc1_transfer", (req,)).await
+    ) -> Result<BlockIndex, TransferError> {
+        ic_cdk::call::<(TransferArg,), (Result<BlockIndex, TransferError>,)>(
+            ledger_principal,
+            "icrc1_transfer",
+            (req.transfer_args,),
+        )
+        .await
     }
 }
 
@@ -238,12 +243,7 @@ async fn call_icrc1_transfer(
         &req.transfer_args.to,
     );
 
-    let call_result = ic_cdk::call::<(TransferArg,), (Result<BlockIndex, TransferError>,)>(
-        ledger_principal,
-        "icrc1_transfer",
-        (req.transfer_args,),
-    )
-    .await;
+    let call_result = InterCanisterCallManager::icrc1_transfer(ledger_principal, req.clone()).await;
 
     let key = match req.sweeped_index {
         Some(data) => data,

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -67,7 +67,9 @@ fn includes_hash(vec_to_check: &Vec<u8>) -> bool {
             match array_ref {
                 Some(array_ref) => {
                     let data: [u8; 32] = *array_ref;
-                    let hash_key = data.to_u64_hash();
+                    let subaccount = Subaccount(data);
+                    let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
+                    let hash_key = subaccountid.to_u64_hash();
 
                     LIST_OF_SUBACCOUNTS.with(|subaccounts| {
                         let subaccounts_borrow = subaccounts.borrow();

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -1,6 +1,8 @@
 use candid::{CandidType, Deserialize, Principal};
 use core::future::Future;
-use futures::{stream::FuturesUnordered, StreamExt};
+// use core::slice::SlicePattern;
+// use futures::{stream::FuturesUnordered, StreamExt};
+use ic_cdk::api;
 use ic_cdk::api::call::CallResult;
 use ic_cdk_macros::*;
 use ic_cdk_timers::TimerId;
@@ -13,8 +15,8 @@ mod memory;
 mod tests;
 mod types;
 
-use ic_ledger_types::{AccountIdentifier, Subaccount};
-use icrc_ledger_types::icrc1::transfer::{BlockIndex, TransferArg, TransferError};
+use ic_ledger_types::{AccountIdentifier, Subaccount, TransferArgs, Tokens, Memo, MAINNET_LEDGER_CANISTER_ID, BlockIndex};
+use ic_ledger_types;
 
 use memory::{
     CUSTODIAN_PRINCIPAL, INTERVAL_IN_SECONDS, LAST_SUBACCOUNT_NONCE, NEXT_BLOCK, PRINCIPAL,
@@ -67,9 +69,7 @@ fn includes_hash(vec_to_check: &Vec<u8>) -> bool {
             match array_ref {
                 Some(array_ref) => {
                     let data: [u8; 32] = *array_ref;
-                    let subaccount = Subaccount(data);
-                    let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
-                    let hash_key = subaccountid.to_u64_hash();
+                    let hash_key = data.to_u64_hash();
 
                     LIST_OF_SUBACCOUNTS.with(|subaccounts| {
                         let subaccounts_borrow = subaccounts.borrow();
@@ -110,6 +110,81 @@ impl IcCdkSpawnManagerTrait for IcCdkSpawnManager {
     }
 }
 
+fn get_subaccount(accountid: &AccountIdentifier) -> Result<Subaccount, Error> {
+    LIST_OF_SUBACCOUNTS.with(|subaccounts| {
+        let subaccounts_borrow = subaccounts.borrow();
+        let account_id_hash = accountid.to_u64_hash();
+        // find matching hashkey
+        match subaccounts_borrow.get(&account_id_hash) {
+            Some(value) => Ok(*value),
+            None => Err(Error {
+                message: "Account not found".to_string(),
+            }),
+        }
+    })
+}
+
+
+fn to_refund_args(tx: &StoredTransactions) -> Result<TransferArgs, Error> {
+    let operation = tx.operation.as_ref().unwrap();
+    match operation {
+        Operation::Transfer(data) => {
+
+            // construct refund destination
+            let topup_from = data.from.clone();
+            let topup_from = topup_from.as_slice();
+            let refund_to = AccountIdentifier::from_slice(topup_from).map_err(|err|{
+                ic_cdk::println!("Error: {:?}", err);
+                Error {message: "Error converting from to AccountIdentifier".to_string(),}
+            })?;
+            
+            // construct refund source of funds
+            let topup_to = data.to.clone();
+            let topup_to = topup_to.as_slice();
+            let refund_source = AccountIdentifier::from_slice(topup_to).map_err(|err|{
+                ic_cdk::println!("Error: {:?}", err);
+                Error {message: "Error converting to to AccountIdentifier".to_string(),}
+            })?;
+            let result = get_subaccount(&refund_source);
+            let refund_source_subaccount = result.map_err(|err|{
+                ic_cdk::println!("Error: {:?}", err);
+                Error {message: "Error getting to_subaccount".to_string(),}
+            })?;
+
+            ic_cdk::println!("refund_source_subaccount: {:?}", refund_source_subaccount);
+
+            let amount = data.amount.e8s - 10_000;
+            Ok(TransferArgs {
+                memo: Memo(0),
+                amount: Tokens::from_e8s(amount),
+                from_subaccount: Some(refund_source_subaccount),
+                fee: Tokens::from_e8s(10_000),
+                to: refund_to,
+                created_at_time: None,
+            })
+        },
+        _ => Err(Error {message: "Operation is not a transfer".to_string(),}),
+    } // end match
+}
+
+fn update_status(tx: &StoredTransactions, status: SweepStatus) -> Result<(), Error> {
+    let mut tx = tx.clone();
+    
+    tx.sweep_status = status;
+
+    let prev_tx = TRANSACTIONS.with(|transactions_ref| {
+        let mut transactions = transactions_ref.borrow_mut();
+        transactions.insert(tx.index, tx)
+    });
+
+    match prev_tx {
+        Some(_) => Ok(()),
+        None => Err(Error {
+            message: "Transaction not found when updating".to_string(),
+        }),
+    }
+}
+
 #[cfg(not(test))]
 impl InterCanisterCallManagerTrait for InterCanisterCallManager {
     async fn query_blocks(
@@ -119,16 +194,16 @@ impl InterCanisterCallManagerTrait for InterCanisterCallManager {
         ic_cdk::call(ledger_principal, "query_blocks", (req,)).await
     }
 
-    async fn icrc1_transfer(
-        ledger_principal: Principal,
-        req: Icrc1TransferRequest,
-    ) -> Result<BlockIndex, TransferError> {
-        ic_cdk::call::<(TransferArg,), (Result<BlockIndex, TransferError>,)>(
-            ledger_principal,
-            "icrc1_transfer",
-            (req.transfer_args,),
-        )
-        .await
+    async fn transfer(args: TransferArgs) -> Result<BlockIndex, String> {
+        let result = ic_ledger_types::transfer(MAINNET_LEDGER_CANISTER_ID, args)
+        .await;
+
+        let result = result.unwrap();
+
+        match result {
+            Ok(block_index) => Ok(block_index),
+            Err(e) => Err(format!("transfer error: {:?}", e.to_string())),       
+        }
     }
 }
 
@@ -235,57 +310,6 @@ async fn call_query_blocks() {
     let _ = NEXT_BLOCK.with(|next_block_ref| next_block_ref.borrow_mut().set(block_count));
 }
 
-async fn call_icrc1_transfer(
-    ledger_principal: Principal,
-    req: Icrc1TransferRequest,
-) -> Result<Option<StoredTransactions>, &'static str> {
-    ic_cdk::println!(
-        "Transferring {} tokens to account {}",
-        &req.transfer_args.amount,
-        &req.transfer_args.to,
-    );
-
-    let call_result = InterCanisterCallManager::icrc1_transfer(ledger_principal, req.clone()).await;
-
-    let key = match req.sweeped_index {
-        Some(data) => data,
-        None => {
-            ic_cdk::println!("Skipping state mutation because sweeped index is not supplied");
-            return Ok(None);
-        }
-    };
-
-    match call_result {
-        Ok(_) => TRANSACTIONS.with(|transactions_ref| {
-            let mut transaction = match { transactions_ref.borrow().get(&key).clone() } {
-                Some(transaction) => transaction,
-                None => {
-                    return Err("");
-                }
-            };
-
-            transaction.sweep_status = SweepStatus::Swept;
-
-            let mut transaction_borrow_mut = transactions_ref.borrow_mut();
-            transaction_borrow_mut.insert(key.clone(), transaction.clone());
-            Ok(Some(transaction))
-        }),
-        Err(_) => TRANSACTIONS.with(|transactions_ref| {
-            let mut transaction = match { transactions_ref.borrow().get(&key).clone() } {
-                Some(transaction) => transaction,
-                None => {
-                    return Err("");
-                }
-            };
-
-            transaction.sweep_status = SweepStatus::FailedToSweep;
-
-            let mut transaction_borrow_mut = transactions_ref.borrow_mut();
-            transaction_borrow_mut.insert(key.clone(), transaction.clone());
-            Ok(Some(transaction))
-        }),
-    }
-}
 
 #[cfg(not(test))]
 impl TimerManagerTrait for TimerManager {
@@ -338,10 +362,7 @@ async fn init(seconds: u64, nonce: u32, ledger_principal: String, custodian_prin
 
 fn reconstruct_subaccounts() {
     let nonce: u32 = get_nonce();
-    let account = CUSTODIAN_PRINCIPAL
-        .with(|stored_ref| stored_ref.borrow().get().clone())
-        .get_principal()
-        .expect("Custodian principal is not set");
+    let account = api::id();
 
     ic_cdk::println!("Reconstructing subaccounts for account: {:?}", account);
     for i in 0..nonce {
@@ -349,6 +370,9 @@ fn reconstruct_subaccounts() {
         let subaccount = to_subaccount(i);
         let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
         let account_id_hash = subaccountid.to_u64_hash();
+
+        ic_cdk::println!("hash: {} - {}", account_id_hash, subaccountid.to_hex());
+
         LIST_OF_SUBACCOUNTS.with(|list_ref| {
             list_ref.borrow_mut().insert(account_id_hash, subaccount);
         });
@@ -391,6 +415,15 @@ fn get_nonce() -> u32 {
     LAST_SUBACCOUNT_NONCE.with(|nonce_ref| *nonce_ref.borrow().get())
 }
 
+#[query]
+fn get_canister_principal() -> String {
+    // Retrieve the principal ID of the canister
+    let principal_id = api::id();
+    
+    // Convert the Principal to a string to easily return or log it
+    principal_id.to_string()
+}
+
 fn to_subaccount(nonce: u32) -> Subaccount {
     let mut subaccount = Subaccount([0; 32]);
     let nonce_bytes = nonce.to_be_bytes(); // Converts u32 to an array of 4 bytes
@@ -399,11 +432,8 @@ fn to_subaccount(nonce: u32) -> Subaccount {
 }
 
 fn to_subaccount_id(subaccount: Subaccount) -> AccountIdentifier {
-    let account = CUSTODIAN_PRINCIPAL
-        .with(|stored_ref| stored_ref.borrow().get().clone())
-        .get_principal()
-        .expect("Custodian principal is not set");
-    AccountIdentifier::new(&account, &subaccount)
+    let principal_id = api::id();
+    AccountIdentifier::new(&principal_id, &subaccount)
 }
 
 fn from_hex(hex: &str) -> Result<[u8; 32], Error> {
@@ -563,17 +593,6 @@ fn clear_transactions(
 
 #[update]
 async fn refund(transaction_index: u64) -> Result<String, Error> {
-    let ledger_principal_opt = PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
-
-    let ledger_principal = match ledger_principal_opt.get_principal() {
-        Some(result) => result,
-        None => {
-            return Err(Error {
-                message: "Principal is not set".to_string(),
-            });
-        }
-    };
-
     let transaction_opt = TRANSACTIONS
         .with(|transactions_ref| transactions_ref.borrow().get(&transaction_index).clone());
 
@@ -586,109 +605,90 @@ async fn refund(transaction_index: u64) -> Result<String, Error> {
         }
     };
 
-    let subaccount = match transaction.operation {
-        Some(Operation::Transfer(data)) => {
-            let to = data.to.clone();
-            match &data.spender {
-                Some(spender) => (includes_hash(&to), to, spender.clone(), data.amount.e8s),
-                None => (false, to, vec![], data.amount.e8s),
-            }
-        }
-        _ => (false, vec![], vec![], 0),
-    };
+    // construct transfer args
+    let transfer_args = to_refund_args(&transaction)?;
 
-    if !subaccount.0 {
-        return Err(Error {
-            message: "Cannot confirm receiver and spender".to_string(),
-        });
-    }
+    InterCanisterCallManager::transfer(transfer_args)
+        .await
+        .map_err(|e| Error {
+            message: e,
+        })?;
 
-    let transfer_args: TransferArg = TransferArg {
-        memo: None,
-        amount: subaccount.3.into(),
-        from_subaccount: None,
-        fee: None,
-        to: Principal::from_slice(&subaccount.2).into(),
-        created_at_time: None,
-    };
-
-    let req = Icrc1TransferRequest::new(transfer_args, None);
-
-    let _ = call_icrc1_transfer(ledger_principal, req).await;
-
-    Ok("Refund is being requested".to_string())
+    update_status(&transaction, SweepStatus::Swept)?;
+    
+    Ok("Refund & tx update is successful".to_string())
 }
 
-#[update]
-async fn sweep_user_vault() -> Result<String, Error> {
-    let ledger_principal_opt = PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
+// #[update]
+// async fn sweep_user_vault() -> Result<String, Error> {
+//     let ledger_principal_opt = PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
 
-    let ledger_principal = match ledger_principal_opt.get_principal() {
-        Some(result) => result,
-        None => {
-            return Err(Error {
-                message: "Principal is not set".to_string(),
-            });
-        }
-    };
+//     let ledger_principal = match ledger_principal_opt.get_principal() {
+//         Some(result) => result,
+//         None => {
+//             return Err(Error {
+//                 message: "Principal is not set".to_string(),
+//             });
+//         }
+//     };
 
-    let custodian_principal_opt =
-        CUSTODIAN_PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
+//     let custodian_principal_opt =
+//         CUSTODIAN_PRINCIPAL.with(|stored_ref| stored_ref.borrow().get().clone());
 
-    let custodian_principal = match custodian_principal_opt.get_principal() {
-        Some(result) => result,
-        None => {
-            return Err(Error {
-                message: "Custodian principal is not set".to_string(),
-            });
-        }
-    };
+//     let custodian_principal = match custodian_principal_opt.get_principal() {
+//         Some(result) => result,
+//         None => {
+//             return Err(Error {
+//                 message: "Custodian principal is not set".to_string(),
+//             });
+//         }
+//     };
 
-    let mut icrc1_futures = FuturesUnordered::new();
-    let _ = TRANSACTIONS.with(|transactions_ref| {
-        let mut transactions: Vec<(u64, StoredTransactions)> = {
-            transactions_ref
-                .borrow()
-                .iter()
-                .filter(|transaction| transaction.1.sweep_status == SweepStatus::NotSwept)
-                .map(|(key, transaction)| (key.clone(), transaction.clone()))
-                .collect()
-        };
+//     let mut icrc1_futures = FuturesUnordered::new();
+//     let _ = TRANSACTIONS.with(|transactions_ref| {
+//         let mut transactions: Vec<(u64, StoredTransactions)> = {
+//             transactions_ref
+//                 .borrow()
+//                 .iter()
+//                 .filter(|transaction| transaction.1.sweep_status == SweepStatus::NotSwept)
+//                 .map(|(key, transaction)| (key.clone(), transaction.clone()))
+//                 .collect()
+//         };
 
-        for (key, transaction) in transactions.iter_mut().map(|(k, t)| (*k, t.clone())) {
-            icrc1_futures.push(async move {
-                let subaccount = match transaction.operation {
-                    Some(Operation::Transfer(data)) => {
-                        let to = data.to.clone();
-                        (includes_hash(&to), to, data.amount.e8s)
-                    }
-                    _ => (false, vec![], 0),
-                };
+//         for (key, transaction) in transactions.iter_mut().map(|(k, t)| (*k, t.clone())) {
+//             icrc1_futures.push(async move {
+//                 let subaccount = match transaction.operation {
+//                     Some(Operation::Transfer(data)) => {
+//                         let to = data.to.clone();
+//                         (includes_hash(&to), to, data.amount.e8s)
+//                     }
+//                     _ => (false, vec![], 0),
+//                 };
 
-                if subaccount.0 {
-                    let transfer_args: TransferArg = TransferArg {
-                        memo: None,
-                        amount: subaccount.2.into(),
-                        from_subaccount: None,
-                        fee: None,
-                        to: custodian_principal.into(),
-                        created_at_time: None,
-                    };
-                    let req = Icrc1TransferRequest::new(transfer_args, Some(key));
+//                 if subaccount.0 {
+//                     let transfer_args: TransferArg = TransferArg {
+//                         memo: None,
+//                         amount: subaccount.2.into(),
+//                         from_subaccount: None,
+//                         fee: None,
+//                         to: custodian_principal.into(),
+//                         created_at_time: None,
+//                     };
+//                     let req = Icrc1TransferRequest::new(transfer_args, Some(key));
 
-                    let _response = call_icrc1_transfer(ledger_principal, req).await;
-                }
-            });
-        }
-    });
+//                     let _response = call_icrc1_transfer(ledger_principal, req).await;
+//                 }
+//             });
+//         }
+//     });
 
-    // Await all futures to complete their operations
-    while let Some(_result) = icrc1_futures.next().await {
-        // Process result if necessary
-    }
+//     // Await all futures to complete their operations
+//     while let Some(_result) = icrc1_futures.next().await {
+//         // Process result if necessary
+//     }
 
-    Ok("Subaccounts are swept to vault".to_string())
-}
+//     Ok("Subaccounts are swept to vault".to_string())
+// }
 
 #[query]
 fn canister_status() -> Result<String, Error> {

--- a/src/icp_prototype_backend/src/lib.rs
+++ b/src/icp_prototype_backend/src/lib.rs
@@ -672,7 +672,8 @@ async fn sweep() -> Result<Vec<String>, Error> {
             .collect();
     
         // If filtered_transactions.len() is less than up_to_count, return all transactions
-        let up_to_count = 10;
+        // max concurrent calls allowed by the IC is 500
+        let up_to_count = 100;
         let skip = if filtered_transactions.len() < up_to_count {
             0
         } else {

--- a/src/icp_prototype_backend/src/tests.rs
+++ b/src/icp_prototype_backend/src/tests.rs
@@ -29,6 +29,7 @@ mod tests {
         let subaccount = Subaccount([1u8; 32]);
         let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
         let account_id_hash = subaccountid.to_u64_hash();
+        ic_cdk::println!("hash_key: {}", account_id_hash);
 
         // Insert the test hash into LIST_OF_SUBACCOUNTS.
         LIST_OF_SUBACCOUNTS.with(|list_ref| {
@@ -376,6 +377,13 @@ mod tests {
     }
 
     fn refund_setup() {
+        // Setup CUSTODIAN_PRINCIPAL with a valid Principal
+        let custodian_principal = STATIC_PRINCIPAL.clone();
+        CUSTODIAN_PRINCIPAL.with(|cp| {
+            let stored_custodian_principal = StoredPrincipal::new(custodian_principal.clone());
+            let _ = cp.borrow_mut().set(stored_custodian_principal);
+        });
+
         // Setup principal
         PRINCIPAL.with(|principal_ref| {
             let stored_principal = StoredPrincipal::new(*STATIC_PRINCIPAL);
@@ -390,16 +398,23 @@ mod tests {
             let mut subaccounts_mut = subaccounts.borrow_mut();
 
             let to_arr = vec_to_array(to.clone());
-            let account_id_hash = to_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(to_arr));
+            let to_subaccount = Subaccount(to_arr.clone());
+            let to_subaccountid: AccountIdentifier = to_subaccount_id(to_subaccount.clone());
+            let account_id_hash = to_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, to_subaccount);
 
             let from_arr = vec_to_array(from.clone());
-            let account_id_hash = from_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(from_arr));
+            let from_subaccount = Subaccount(from_arr.clone());
+            let from_subaccountid: AccountIdentifier = to_subaccount_id(from_subaccount.clone());
+            let account_id_hash = from_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, from_subaccount);
 
             let spender_arr = vec_to_array(spender.clone());
-            let account_id_hash = spender_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(spender_arr));
+            let spender_subaccount = Subaccount(spender_arr.clone());
+            let spender_subaccountid: AccountIdentifier =
+                to_subaccount_id(spender_subaccount.clone());
+            let account_id_hash = spender_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, spender_subaccount);
         });
 
         // Setup transactions
@@ -478,17 +493,17 @@ mod tests {
     }
 
     fn setup_sweep_environment() {
-        // Setup PRINCIPAL with a valid Principal
-        PRINCIPAL.with(|p| {
-            let stored_principal = StoredPrincipal::new(STATIC_PRINCIPAL.clone());
-            let _ = p.borrow_mut().set(stored_principal);
-        });
-
         // Setup CUSTODIAN_PRINCIPAL with a valid Principal
         let custodian_principal = STATIC_PRINCIPAL.clone();
         CUSTODIAN_PRINCIPAL.with(|cp| {
             let stored_custodian_principal = StoredPrincipal::new(custodian_principal.clone());
             let _ = cp.borrow_mut().set(stored_custodian_principal);
+        });
+
+        // Setup PRINCIPAL with a valid Principal
+        PRINCIPAL.with(|p| {
+            let stored_principal = StoredPrincipal::new(STATIC_PRINCIPAL.clone());
+            let _ = p.borrow_mut().set(stored_principal);
         });
 
         let to = vec![1u8; 32];
@@ -499,16 +514,23 @@ mod tests {
             let mut subaccounts_mut = subaccounts.borrow_mut();
 
             let to_arr = vec_to_array(to.clone());
-            let account_id_hash = to_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(to_arr));
+            let to_subaccount = Subaccount(to_arr.clone());
+            let to_subaccountid: AccountIdentifier = to_subaccount_id(to_subaccount.clone());
+            let account_id_hash = to_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, to_subaccount);
 
             let from_arr = vec_to_array(from.clone());
-            let account_id_hash = from_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(from_arr));
+            let from_subaccount = Subaccount(from_arr.clone());
+            let from_subaccountid: AccountIdentifier = to_subaccount_id(from_subaccount.clone());
+            let account_id_hash = from_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, from_subaccount);
 
             let spender_arr = vec_to_array(spender.clone());
-            let account_id_hash = spender_arr.to_u64_hash();
-            subaccounts_mut.insert(account_id_hash, Subaccount(spender_arr));
+            let spender_subaccount = Subaccount(spender_arr.clone());
+            let spender_subaccountid: AccountIdentifier =
+                to_subaccount_id(spender_subaccount.clone());
+            let account_id_hash = spender_subaccountid.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, spender_subaccount);
         });
 
         // Populate TRANSACTIONS with a mixture of swept and not swept transactions

--- a/src/icp_prototype_backend/src/tests.rs
+++ b/src/icp_prototype_backend/src/tests.rs
@@ -19,6 +19,13 @@ mod tests {
 
     // Setup function to add a predefined hash to the LIST_OF_SUBACCOUNTS for testing.
     fn setup() {
+        // Setup CUSTODIAN_PRINCIPAL with a valid Principal
+        let custodian_principal = STATIC_PRINCIPAL.clone();
+        CUSTODIAN_PRINCIPAL.with(|cp| {
+            let stored_custodian_principal = StoredPrincipal::new(custodian_principal.clone());
+            let _ = cp.borrow_mut().set(stored_custodian_principal);
+        });
+
         let subaccount = Subaccount([1u8; 32]);
         let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
         let account_id_hash = subaccountid.to_u64_hash();

--- a/src/icp_prototype_backend/src/tests.rs
+++ b/src/icp_prototype_backend/src/tests.rs
@@ -4,6 +4,7 @@ mod tests {
     use crate::*;
     use once_cell::sync::Lazy;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio;
 
     impl TimerManagerTrait for TimerManager {
         fn set_timer(_interval: std::time::Duration) -> TimerId {
@@ -18,15 +19,13 @@ mod tests {
 
     // Setup function to add a predefined hash to the LIST_OF_SUBACCOUNTS for testing.
     fn setup() {
-        let hash = [1u8; 32];
-        let hash_u64 = hash_to_u64(&hash);
-        let account_identifier = AccountIdentifier { hash: [1u8; 28] }; // Force a compatible hash.
+        let subaccount = Subaccount([1u8; 32]);
+        let subaccountid: AccountIdentifier = to_subaccount_id(subaccount.clone());
+        let account_id_hash = subaccountid.to_u64_hash();
 
         // Insert the test hash into LIST_OF_SUBACCOUNTS.
-        LIST_OF_SUBACCOUNTS.with(|subaccounts| {
-            subaccounts
-                .borrow_mut()
-                .insert(hash_u64, account_identifier);
+        LIST_OF_SUBACCOUNTS.with(|list_ref| {
+            list_ref.borrow_mut().insert(account_id_hash, subaccount);
         });
     }
 
@@ -168,26 +167,6 @@ mod tests {
 
         assert_eq!(stored_principal.get_principal(), Some(*STATIC_PRINCIPAL));
     }
-
-    // #[test]
-    // fn test_increment_nonce() {
-    //     let nonce = increment_nonce();
-    //     assert_eq!(nonce, 1);
-    // }
-
-    #[test]
-    fn test_convert_to_subaccount() {
-        let nonce = 1;
-        let subaccount = convert_to_subaccount(nonce);
-        assert_eq!(subaccount.0[28..32], [0, 0, 0, 1]);
-    }
-
-    // #[test]
-    // fn test_account_id() {
-    //     let account_id = account_id();
-    //     let hex = to_hex_string(account_id.to_address());
-    //     assert_eq!(hex.len(), 64);
-    // }
 
     // Utility function to populate transactions for testing
     fn populate_transactions(count: u64, timestamp_nanos: Option<u64>) {
@@ -404,20 +383,16 @@ mod tests {
             let mut subaccounts_mut = subaccounts.borrow_mut();
 
             let to_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&to_arr);
-            let account_id = AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(to_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let account_id_hash = to_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(to_arr));
 
-            let from_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&vec_to_array(from.clone()));
-            let account_id = AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(from_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let from_arr = vec_to_array(from.clone());
+            let account_id_hash = from_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(from_arr));
 
-            let spender_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&vec_to_array(spender.clone()));
-            let account_id =
-                AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(spender_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let spender_arr = vec_to_array(spender.clone());
+            let account_id_hash = spender_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(spender_arr));
         });
 
         // Setup transactions
@@ -450,22 +425,22 @@ mod tests {
         TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
     }
 
-    #[test]
-    fn test_refund_valid_transaction() {
+    #[tokio::test]
+    async fn test_refund_valid_transaction() {
         refund_setup();
 
         // Your refund test logic for a valid transaction
         let result = refund(1);
         assert!(
-            result.is_ok(),
+            result.await.is_ok(),
             "Refund should succeed for a valid transaction"
         );
 
         refund_teardown();
     }
 
-    #[test]
-    fn test_refund_unset_principal() {
+    #[tokio::test]
+    async fn test_refund_unset_principal() {
         refund_setup();
         // Unset the principal to simulate the error condition
         PRINCIPAL.with(|principal_ref| {
@@ -474,21 +449,21 @@ mod tests {
 
         let result = refund(1);
         assert!(
-            result.is_err(),
+            result.await.is_err(),
             "Refund should fail if the principal is not set"
         );
 
         refund_teardown();
     }
 
-    #[test]
-    fn test_refund_nonexistent_transaction() {
+    #[tokio::test]
+    async fn test_refund_nonexistent_transaction() {
         refund_setup();
 
         // Attempt to refund a transaction that doesn't exist
         let result = refund(999); // Assuming transaction with index 999 does not exist
         assert!(
-            result.is_err(),
+            result.await.is_err(),
             "Refund should fail for a non-existent transaction"
         );
 
@@ -517,20 +492,16 @@ mod tests {
             let mut subaccounts_mut = subaccounts.borrow_mut();
 
             let to_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&to_arr);
-            let account_id = AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(to_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let account_id_hash = to_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(to_arr));
 
-            let from_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&vec_to_array(from.clone()));
-            let account_id = AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(from_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let from_arr = vec_to_array(from.clone());
+            let account_id_hash = from_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(from_arr));
 
-            let spender_arr = vec_to_array(to.clone());
-            let account_id_hash = hash_to_u64(&vec_to_array(spender.clone()));
-            let account_id =
-                AccountIdentifier::new(*STATIC_PRINCIPAL, Some(Subaccount(spender_arr)));
-            subaccounts_mut.insert(account_id_hash, account_id);
+            let spender_arr = vec_to_array(spender.clone());
+            let account_id_hash = spender_arr.to_u64_hash();
+            subaccounts_mut.insert(account_id_hash, Subaccount(spender_arr));
         });
 
         // Populate TRANSACTIONS with a mixture of swept and not swept transactions
@@ -575,12 +546,12 @@ mod tests {
         let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
     }
 
-    #[test]
-    fn test_sweep_user_vault_successful_sweep() {
+    #[tokio::test]
+    async fn test_sweep_user_vault_successful_sweep() {
         setup_sweep_environment();
 
         let result = sweep_user_vault();
-        assert!(result.is_ok(), "Sweeping should be successful.");
+        assert!(result.await.is_ok(), "Sweeping should be successful.");
 
         TRANSACTIONS.with(|t| {
             assert!(
@@ -594,108 +565,47 @@ mod tests {
         teardown_sweep_environment();
     }
 
-    #[test]
-    fn test_sweep_user_vault_no_principal_set() {
+    #[tokio::test]
+    async fn test_sweep_user_vault_no_principal_set() {
         setup_sweep_environment();
         // Unset the principal
         let _ = PRINCIPAL.with(|p| p.borrow_mut().set(StoredPrincipal::default()));
 
         let result = sweep_user_vault();
         assert!(
-            result.is_err(),
+            result.await.is_err(),
             "Sweeping should fail without a set principal."
         );
 
         teardown_sweep_environment();
     }
 
-    #[test]
-    fn test_sweep_user_vault_no_custodian_principal_set() {
+    #[tokio::test]
+    async fn test_sweep_user_vault_no_custodian_principal_set() {
         setup_sweep_environment();
         // Unset the custodian principal
         let _ = CUSTODIAN_PRINCIPAL.with(|cp| cp.borrow_mut().set(StoredPrincipal::default()));
 
         let result = sweep_user_vault();
         assert!(
-            result.is_err(),
+            result.await.is_err(),
             "Sweeping should fail without a set custodian principal."
         );
 
         teardown_sweep_environment();
     }
 
-    #[test]
-    fn test_sweep_user_vault_no_transactions_to_sweep() {
+    #[tokio::test]
+    async fn test_sweep_user_vault_no_transactions_to_sweep() {
         setup_sweep_environment();
         // Clear transactions to simulate no transactions to sweep
         TRANSACTIONS.with(|t| t.borrow_mut().clear_new());
 
         let result = sweep_user_vault();
         assert!(
-            result.is_ok(),
+            result.await.is_ok(),
             "Sweeping should succeed even with no transactions to sweep."
         );
-
-        teardown_sweep_environment();
-    }
-
-    fn setup_transactions_with_error() {
-        let to = vec![1u8; 32];
-        let from = vec![2u8; 32];
-
-        // Setup a transaction expected to fail during the transfer, leading to error handling
-        TRANSACTIONS.with(|transactions_ref| {
-            transactions_ref.borrow_mut().insert(
-                3,
-                StoredTransactions {
-                    index: 3,
-                    memo: 102,
-                    icrc1_memo: None,
-                    operation: Some(Operation::Transfer(Transfer {
-                        to: to,
-                        fee: E8s { e8s: 100 },
-                        from: from,
-                        amount: E8s { e8s: 500 },
-                        spender: Some(STATIC_PRINCIPAL.as_slice().to_vec()),
-                    })),
-                    created_at_time: Timestamp { timestamp_nanos: 0 },
-                    sweep_status: SweepStatus::NotSwept,
-                },
-            );
-        });
-    }
-
-    #[test]
-    fn test_icrc1_transfer_error_handling() {
-        setup_sweep_environment();
-        setup_transactions_with_error();
-
-        // Memo corresponding to the transaction we expect to handle error for
-        let test_memo = 3_u64.to_be_bytes().to_vec();
-        let key = vec_u8_to_u64(test_memo.clone());
-
-        // Create a request with the memo
-        let request = Icrc1TransferRequest::new(
-            ToRecord::new(*STATIC_PRINCIPAL, None),
-            None,
-            Some(test_memo),
-            None,
-            None,
-            500,
-        );
-
-        icrc1_transfer_error_handling(request);
-
-        // Check if the transaction was marked as FailedToSweep
-        TRANSACTIONS.with(|transactions_ref| {
-            let transactions_borrow = transactions_ref.borrow();
-            let transaction = transactions_borrow.get(&key).unwrap();
-            assert_eq!(
-                transaction.sweep_status,
-                SweepStatus::FailedToSweep,
-                "The transaction should be marked as FailedToSweep."
-            );
-        });
 
         teardown_sweep_environment();
     }

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -2,6 +2,7 @@ use candid::{CandidType, Deserialize, Principal};
 use core::future::Future;
 use ic_cdk::api::call::CallResult;
 use ic_cdk_timers::TimerId;
+use icrc_ledger_types::icrc1::transfer::TransferArg;
 use serde::Serialize;
 use std::{borrow::Cow, collections::HashMap};
 
@@ -13,30 +14,15 @@ pub struct QueryBlocksRequest {
 
 #[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct Icrc1TransferRequest {
-    to: ToRecord,
-    fee: Option<u64>,
-    pub memo: Option<Vec<u8>>,
-    from_subaccount: Option<Vec<u8>>,
-    created_at_time: Option<u64>,
-    amount: u64,
+    pub transfer_args: TransferArg,
+    pub sweeped_index: Option<u64>,
 }
 
 impl Icrc1TransferRequest {
-    pub fn new(
-        to: ToRecord,
-        fee: Option<u64>,
-        memo: Option<Vec<u8>>,
-        from_subaccount: Option<Vec<u8>>,
-        created_at_time: Option<u64>,
-        amount: u64,
-    ) -> Self {
+    pub fn new(transfer_args: TransferArg, sweeped_index: Option<u64>) -> Self {
         Self {
-            to,
-            fee,
-            memo,
-            from_subaccount,
-            created_at_time,
-            amount,
+            transfer_args,
+            sweeped_index,
         }
     }
 }

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -19,25 +19,10 @@ pub struct Icrc1TransferRequest {
     pub sweeped_index: Option<u64>,
 }
 
-impl Icrc1TransferRequest {
-    pub fn new(transfer_args: TransferArg, sweeped_index: Option<u64>) -> Self {
-        Self {
-            transfer_args,
-            sweeped_index,
-        }
-    }
-}
-
 #[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct ToRecord {
     owner: Principal,
     subaccount: Option<Vec<u8>>,
-}
-
-impl ToRecord {
-    pub fn new(owner: Principal, subaccount: Option<Vec<u8>>) -> Self {
-        Self { owner, subaccount }
-    }
 }
 
 #[derive(CandidType, Deserialize, Serialize, Debug, Clone, PartialEq)]

--- a/src/icp_prototype_backend/src/types.rs
+++ b/src/icp_prototype_backend/src/types.rs
@@ -5,6 +5,7 @@ use ic_cdk_timers::TimerId;
 use icrc_ledger_types::icrc1::transfer::TransferArg;
 use serde::Serialize;
 use std::{borrow::Cow, collections::HashMap};
+use ic_ledger_types::{TransferArgs, BlockIndex};
 
 #[derive(CandidType, Deserialize, Serialize, Clone)]
 pub struct QueryBlocksRequest {
@@ -298,10 +299,8 @@ pub trait InterCanisterCallManagerTrait {
         ledger_principal: Principal,
         req: QueryBlocksRequest,
     ) -> CallResult<(QueryBlocksResponse,)>;
-    async fn icrc1_transfer(
-        ledger_principal: Principal,
-        req: Icrc1TransferRequest,
-    ) -> CallResult<(Icrc1TransferResponse,)>;
+
+    async fn transfer(args: TransferArgs) -> Result<BlockIndex, String>;
 }
 
 pub struct InterCanisterCallManager;


### PR DESCRIPTION
- we are using `transfer` method in place of `icrc`_transfer` as we do not have sender principal value available to us
- refund prior receiver is correctly retrieved using canister's own principal instead of preconfigure custodian principal
- amount to be sent is subtracted by fee to make the correct balance
- refund processed are refactored into several helper functions